### PR TITLE
Remove more gendered stuff

### DIFF
--- a/src/content/app.js
+++ b/src/content/app.js
@@ -2,10 +2,10 @@
   global.noGender = global.noGender || {}
 
   const APP = global.noGender
-  const INNEN_EXPR = '([:*_]innen|!nnen|Innen)'
-  const IN_EXPR = '([:*_]in|!n|In)[^A-Za-zÄÖÜäöüß]'
-  const INNEN_UND_ODER_EXPR = '[A-Za-zÄÖÜäöüß]+innen (?:und|oder) ([A-Za-zÄÖÜäöü]+)'
-  const UND_ODER_INNEN_EXPR = '([A-Za-zÄÖÜäöüß]+) (?:und|oder) [A-Za-zÄÖÜäöü]+innen'
+  const INNEN_EXPR = '([:*_\/]innen|!nnen|Innen)'
+  const IN_EXPR = '([:*_\/]in|!n|In)[^A-Za-zÄÖÜäöüß]'
+  const INNEN_UND_ODER_EXPR = '(([-]*[A-Za-zÄÖÜäöüß]+?)(i|I)nnen) (?:und|oder) ([-]*\\2+[A-Za-zÄÖÜäöüß]*)'
+  const UND_ODER_INNEN_EXPR = '([-]*[A-Z][A-Za-zÄÖÜäöüß]*) (?:und|oder) (([-]*[A-Z][A-Za-zÄÖÜäöüß]+?)(i|I)nnen)'
 
   /* configuration */
   APP.config = {
@@ -69,7 +69,7 @@
      */
     getInnenUndOderRegExp: function () {
       const regExp = new RegExp(INNEN_UND_ODER_EXPR, 'g')
-      const replace = (term, word) => word
+      const replace = (term, _1, _2, _3, word) => word
       return { regExp, replace }
     },
 

--- a/src/content/list.custom.js
+++ b/src/content/list.custom.js
@@ -8,7 +8,10 @@
     /**
      * Custom replace objects
      */
-    { regExp: /jede[:*_]r/, replace: 'jeder' },
-    { regExp: /ein[:*_]e/, replace: 'ein' },
+    { regExp: /jede[:*_\/]r/, replace: 'jeder' },
+    { regExp: /ein[:*_\/]e/, replace: 'ein' },
+    { regExp: /einem[:*_\/]r/, replace: 'einem' },
+    { regExp: /eines[:*_\/]einer/, replace: 'eines' },
+    { regExp: /den[:*_\/]die/, replace: 'den' },
   ]
 }(typeof window !== 'undefined' ? window : this))

--- a/src/content/script.js
+++ b/src/content/script.js
@@ -47,6 +47,10 @@
    */
   function iterate () {
     const start = Date.now()
+
+    const title = window.document.title
+    window.document.title = degenderfyString(title)
+
     const root = window.document.body
     const walker = window.document
       .createTreeWalker(root, NodeFilter.SHOW_TEXT, null)
@@ -89,31 +93,40 @@
     }
   }
 
+  function degenderfyString (value) {
+    if (regularExpressions.innenUndOder.test(value)) {
+      const { regExp, replace } = APP.helpers.getInnenUndOderRegExp()
+      value = value.replace(regExp, replace)
+      counter++
+    }
+    if (regularExpressions.undOderInnen.test(value)) {
+      const { regExp, replace } = APP.helpers.getUndOderInnenRegExp()
+      value = value.replace(regExp, replace)
+      counter++
+    }
+    if (regularExpressions.wordInnen.test(value)) {
+      value = parseList(value, listPlural)
+    }
+    if (regularExpressions.wordIn.test(value)) {
+      value = parseList(value, listSingular)
+    }
+    listCustom.forEach(({ regExp, replace }) => {
+      if (regExp.test(value)) {
+        value = value.replace(regExp, replace)
+        counter++
+      }
+    })
+
+    return value
+  }
+
   /**
    * Parse nodeValue of given node
    * @param node {Node} node to check
    */
   function parseNode (node) {
     normalizeNodeValue(node)
-    if (regularExpressions.innenUndOder.test(node.nodeValue)) {
-      const { regExp, replace } = APP.helpers.getInnenUndOderRegExp()
-      node.nodeValue = node.nodeValue.replace(regExp, replace)
-    }
-    if (regularExpressions.undOderInnen.test(node.nodeValue)) {
-      const { regExp, replace } = APP.helpers.getUndOderInnenRegExp()
-      node.nodeValue = node.nodeValue.replace(regExp, replace)
-    }
-    if (regularExpressions.wordInnen.test(node.nodeValue)) {
-      node.nodeValue = parseList(node.nodeValue, listPlural)
-    }
-    if (regularExpressions.wordIn.test(node.nodeValue)) {
-      node.nodeValue = parseList(node.nodeValue, listSingular)
-    }
-    listCustom.forEach(({ regExp, replace }) => {
-      if (regExp.test(node.nodeValue)) {
-        node.nodeValue = node.nodeValue.replace(regExp, replace)
-      }
-    })
+    node.nodeValue = degenderfyString(node.nodeValue)
   }
 
   /**

--- a/tests/unit/plural.spec.js
+++ b/tests/unit/plural.spec.js
@@ -920,4 +920,20 @@ describe('no-gender - plural', () => {
       expect(document.body.innerHTML).toBe('Sie alle sind Mitarbeiter!')
     })
   })
+
+  describe('"...innen und ..."', () => {
+    it('should NOT find and replace "gewinnen und sie"', function () {
+      document.body.innerHTML = '"[...]wir können keine Energie daraus gewinnen und sie wird so wieder ausgeschieden'
+      searchAndDestroy()
+      expect(document.body.innerHTML).toBe('"[...]wir können keine Energie daraus gewinnen und sie wird so wieder ausgeschieden')
+    })
+  })
+
+  describe('"... und ...innen"', function () {
+    it('should NOT find and replace "sie und gewinnen"', function () {
+      document.body.innerHTML = '[...]energetisch und gewinnen somit den ersten Platz!'
+      searchAndDestroy()
+      expect(document.body.innerHTML).toBe('[...]energetisch und gewinnen somit den ersten Platz!')
+    })
+  })
 })


### PR DESCRIPTION
- Fixes #3 
- Detects more gendered words
- Checks the title

INNEN_UND_ODER_EXPR:
Compares the first word without the "innen" part to the start of the second word.
"**Ärzt**innen und **Ärzt**e" -> "Ärzte"

UND_ODER_INNEN_EXPR:
Only checks if both words start with a capital letter.
(should be fine in most cases except for when the nouns start with a small letter)

Examples:
Liebe Forum-Nutzer...
-> Liebe Forum-Nutzer...

...einem Tutor...
-> ...einem Tutor...


